### PR TITLE
Create dynamodb, lambda-roles, secrets modules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,3 +28,33 @@ module "github_oidc" {
   aws_region = local.aws_region
   tags       = local.common_tags
 }
+
+module "dynamodb" {
+  source = "./modules/dynamodb"
+
+  project_name   = local.project
+  replica_region = "us-west-2"
+
+  tags = local.common_tags
+}
+
+module "secrets" {
+  source = "./modules/secrets"
+
+  project_name = local.project
+
+  tags = local.common_tags
+}
+
+module "lambda_roles" {
+  source = "./modules/lambda-roles"
+
+  project_name = local.project
+
+  credentials_table_arn       = module.dynamodb.credentials_table_arn
+  bit_indices_table_arn       = module.dynamodb.bit_indices_table_arn
+  baby_jubjub_private_key_arn = module.secrets.baby_jubjub_private_key_arn
+  hmac_key_arn                = module.secrets.hmac_key_arn
+
+  tags = local.common_tags
+}

--- a/modules/dynamodb/main.tf
+++ b/modules/dynamodb/main.tf
@@ -1,0 +1,62 @@
+resource "aws_dynamodb_table" "credentials" {
+  name           = "${var.project_name}-credentials"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "subject_id"
+  range_key      = "credential_id"
+  stream_enabled = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "subject_id"
+    type = "S"
+  }
+
+  attribute {
+    name = "credential_id"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "expires_at"
+    enabled        = true
+  }
+
+  replica {
+    region_name = var.replica_region
+  }
+
+  tags = var.tags
+}
+
+resource "aws_dynamodb_table" "bit_indices" {
+  name           = "${var.project_name}-bit-indices"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "bit_index"
+  stream_enabled = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "bit_index"
+    type = "N"
+  }
+
+  replica {
+    region_name = var.replica_region
+  }
+
+  tags = var.tags
+}
+
+resource "aws_dynamodb_table_item" "bit_indices_metadata" {
+  table_name = aws_dynamodb_table.bit_indices.name
+  hash_key   = aws_dynamodb_table.bit_indices.hash_key
+
+  item = jsonencode({
+    bit_index = { N = "-1" }
+    max_index = { N = "0" }
+  })
+
+  lifecycle {
+    ignore_changes = [item]
+  }
+}

--- a/modules/dynamodb/outputs.tf
+++ b/modules/dynamodb/outputs.tf
@@ -1,0 +1,29 @@
+output "credentials_table_name" {
+  description = "Name of the credentials DynamoDB table"
+  value       = aws_dynamodb_table.credentials.name
+}
+
+output "credentials_table_arn" {
+  description = "ARN of the credentials DynamoDB table"
+  value       = aws_dynamodb_table.credentials.arn
+}
+
+output "credentials_table_stream_arn" {
+  description = "Stream ARN of the credentials DynamoDB table"
+  value       = aws_dynamodb_table.credentials.stream_arn
+}
+
+output "bit_indices_table_name" {
+  description = "Name of the bit_indices DynamoDB table"
+  value       = aws_dynamodb_table.bit_indices.name
+}
+
+output "bit_indices_table_arn" {
+  description = "ARN of the bit_indices DynamoDB table"
+  value       = aws_dynamodb_table.bit_indices.arn
+}
+
+output "bit_indices_table_stream_arn" {
+  description = "Stream ARN of the bit_indices DynamoDB table"
+  value       = aws_dynamodb_table.bit_indices.stream_arn
+}

--- a/modules/dynamodb/variables.tf
+++ b/modules/dynamodb/variables.tf
@@ -1,0 +1,28 @@
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment (e.g., dev, prod)"
+  type        = string
+  default     = "prod"
+}
+
+variable "primary_region" {
+  description = "Primary region for DynamoDB tables"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "replica_region" {
+  description = "Replica region for DynamoDB Global Tables"
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/lambda-roles/main.tf
+++ b/modules/lambda-roles/main.tf
@@ -1,0 +1,205 @@
+resource "aws_iam_role" "issuer_lambda" {
+  name        = "${var.project_name}-issuer-lambda"
+  description = "Execution role for issuer Lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy" "issuer_lambda" {
+  name = "issuer-lambda-policy"
+  role = aws_iam_role.issuer_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBAccess"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:Query",
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem"
+        ]
+        Resource = [
+          var.credentials_table_arn,
+          var.bit_indices_table_arn
+        ]
+      },
+      {
+        Sid    = "SecretsManagerAccess"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = [
+          var.baby_jubjub_private_key_arn,
+          var.hmac_key_arn
+        ]
+      },
+      {
+        Sid    = "CloudWatchLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "revocation_lambda" {
+  name        = "${var.project_name}-revocation-lambda"
+  description = "Execution role for revocation processor Lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy" "revocation_lambda" {
+  name = "revocation-lambda-policy"
+  role = aws_iam_role.revocation_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBAccess"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:UpdateItem"
+        ]
+        Resource = var.credentials_table_arn
+      },
+      {
+        Sid    = "CloudWatchLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "free_lambda" {
+  name        = "${var.project_name}-free-lambda"
+  description = "Execution role for free Lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy" "free_lambda" {
+  name = "free-lambda-policy"
+  role = aws_iam_role.free_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBAccess"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:UpdateItem"
+        ]
+        Resource = var.bit_indices_table_arn
+      },
+      {
+        Sid    = "CloudWatchLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "bitstring_updater_lambda" {
+  name        = "${var.project_name}-bitstring-updater-lambda"
+  description = "Execution role for bitstring updater Lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy" "bitstring_updater_lambda" {
+  name = "bitstring-updater-lambda-policy"
+  role = aws_iam_role.bitstring_updater_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "CloudWatchLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}

--- a/modules/lambda-roles/outputs.tf
+++ b/modules/lambda-roles/outputs.tf
@@ -1,0 +1,39 @@
+output "issuer_lambda_role_arn" {
+  description = "ARN of the issuer Lambda execution role"
+  value       = aws_iam_role.issuer_lambda.arn
+}
+
+output "issuer_lambda_role_name" {
+  description = "Name of the issuer Lambda execution role"
+  value       = aws_iam_role.issuer_lambda.name
+}
+
+output "revocation_lambda_role_arn" {
+  description = "ARN of the revocation Lambda execution role"
+  value       = aws_iam_role.revocation_lambda.arn
+}
+
+output "revocation_lambda_role_name" {
+  description = "Name of the revocation Lambda execution role"
+  value       = aws_iam_role.revocation_lambda.name
+}
+
+output "free_lambda_role_arn" {
+  description = "ARN of the free Lambda execution role"
+  value       = aws_iam_role.free_lambda.arn
+}
+
+output "free_lambda_role_name" {
+  description = "Name of the free Lambda execution role"
+  value       = aws_iam_role.free_lambda.name
+}
+
+output "bitstring_updater_lambda_role_arn" {
+  description = "ARN of the bitstring updater Lambda execution role"
+  value       = aws_iam_role.bitstring_updater_lambda.arn
+}
+
+output "bitstring_updater_lambda_role_name" {
+  description = "Name of the bitstring updater Lambda execution role"
+  value       = aws_iam_role.bitstring_updater_lambda.name
+}

--- a/modules/lambda-roles/variables.tf
+++ b/modules/lambda-roles/variables.tf
@@ -1,0 +1,30 @@
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+}
+
+variable "credentials_table_arn" {
+  description = "ARN of the credentials DynamoDB table"
+  type        = string
+}
+
+variable "bit_indices_table_arn" {
+  description = "ARN of the bit_indices DynamoDB table"
+  type        = string
+}
+
+variable "baby_jubjub_private_key_arn" {
+  description = "ARN of the Baby Jubjub private key secret"
+  type        = string
+}
+
+variable "hmac_key_arn" {
+  description = "ARN of the HMAC key secret"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -1,0 +1,37 @@
+resource "aws_secretsmanager_secret" "baby_jubjub_private_key" {
+  name        = "${var.project_name}/baby-jubjub-private-key"
+  description = "Baby Jubjub EdDSA private key for credential signing"
+
+  tags = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "baby_jubjub_private_key" {
+  secret_id = aws_secretsmanager_secret.baby_jubjub_private_key.id
+  secret_string = jsonencode({
+    private_key = "PLACEHOLDER_REPLACE_WITH_ACTUAL_KEY"
+    description = "Baby Jubjub EdDSA private key in hex format"
+  })
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+resource "aws_secretsmanager_secret" "hmac_key" {
+  name        = "${var.project_name}/hmac-key"
+  description = "HMAC key for credential verification"
+
+  tags = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "hmac_key" {
+  secret_id = aws_secretsmanager_secret.hmac_key.id
+  secret_string = jsonencode({
+    hmac_key    = "PLACEHOLDER_REPLACE_WITH_ACTUAL_KEY"
+    description = "HMAC key in hex format"
+  })
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}

--- a/modules/secrets/outputs.tf
+++ b/modules/secrets/outputs.tf
@@ -1,0 +1,19 @@
+output "baby_jubjub_private_key_arn" {
+  description = "ARN of the Baby Jubjub private key secret"
+  value       = aws_secretsmanager_secret.baby_jubjub_private_key.arn
+}
+
+output "baby_jubjub_private_key_name" {
+  description = "Name of the Baby Jubjub private key secret"
+  value       = aws_secretsmanager_secret.baby_jubjub_private_key.name
+}
+
+output "hmac_key_arn" {
+  description = "ARN of the HMAC key secret"
+  value       = aws_secretsmanager_secret.hmac_key.arn
+}
+
+output "hmac_key_name" {
+  description = "Name of the HMAC key secret"
+  value       = aws_secretsmanager_secret.hmac_key.name
+}

--- a/modules/secrets/variables.tf
+++ b/modules/secrets/variables.tf
@@ -1,0 +1,10 @@
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
### Notes
1. Created DynamoDB module that provisions 2 DynamoDB tables: credentials, bit_indicies. Replication to us-west-2.
2. Created secrets module that provisions 2 secrets: baby-jubjub private key and hmac key.
3. Created lambda-roles module that provisions roles and policies for lambdas. Those roles give correct access to the dynamo db.
4. This PR resolves #1 

### Testing
1. `tofu plan` and diff looks good.