### PR TITLE
Create a lambda-artifacts S3 bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,14 @@ locals {
   }
 }
 
+module "storage" {
+  source = "./modules/storage"
+
+  project_name = local.project
+
+  tags = local.common_tags
+}
+
 module "github_oidc" {
   source = "./modules/github-oidc"
 
@@ -25,8 +33,9 @@ module "github_oidc" {
   infrastructure_role_name    = "ZeroVerifyGitHubActionsInfra"
   lambda_deployment_role_name = "ZeroVerifyGitHubActionsLambdaDeployment"
 
-  aws_region = local.aws_region
-  tags       = local.common_tags
+  aws_region                  = local.aws_region
+  lambda_artifacts_bucket_arn = module.storage.lambda_artifacts_bucket_arn
+  tags                        = local.common_tags
 }
 
 module "dynamodb" {

--- a/modules/github-oidc/main.tf
+++ b/modules/github-oidc/main.tf
@@ -28,8 +28,8 @@ resource "aws_iam_policy" "lambda_deployment" {
           "s3:ListBucket"
         ]
         Resource = [
-          "arn:aws:s3:::zeroverify-*",
-          "arn:aws:s3:::zeroverify-*/*"
+          var.lambda_artifacts_bucket_arn,
+          "${var.lambda_artifacts_bucket_arn}/*"
         ]
       },
       {

--- a/modules/github-oidc/variables.tf
+++ b/modules/github-oidc/variables.tf
@@ -25,6 +25,11 @@ variable "aws_region" {
   type        = string
 }
 
+variable "lambda_artifacts_bucket_arn" {
+  description = "ARN of the Lambda artifacts S3 bucket"
+  type        = string
+}
+
 variable "tags" {
   description = "Tags to apply to resources"
   type        = map(string)

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -1,0 +1,29 @@
+resource "aws_s3_bucket" "lambda_artifacts" {
+  bucket = "${var.project_name}-lambda-artifacts"
+
+  tags = var.tags
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "lambda_artifacts" {
+  bucket = aws_s3_bucket.lambda_artifacts.id
+
+  rule {
+    id     = "abort-incomplete-uploads"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "lambda_artifacts" {
+  bucket = aws_s3_bucket.lambda_artifacts.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/modules/storage/outputs.tf
+++ b/modules/storage/outputs.tf
@@ -1,0 +1,9 @@
+output "lambda_artifacts_bucket_name" {
+  description = "Name of the Lambda artifacts S3 bucket"
+  value       = aws_s3_bucket.lambda_artifacts.bucket
+}
+
+output "lambda_artifacts_bucket_arn" {
+  description = "ARN of the Lambda artifacts S3 bucket"
+  value       = aws_s3_bucket.lambda_artifacts.arn
+}

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -1,0 +1,10 @@
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
### Notes
1. Create storage module that creates a lambda-artifacts S3 bucket that github actions will upload binaries to. 
2. Changed github-oidc provider module to only allow lambda deployment role to have access to this new S3 bucket
3. Resolves #6 

### Testing
1. `tofu plan` and diff looks good